### PR TITLE
Build in container rather than image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,6 @@
 FROM node:10
 MAINTAINER Ansel Santosa <ansel@santosa.family>
 
-# use changes to package.json to force Docker not to use the cache
-# when we change our application's nodejs dependencies:
-COPY package.json /tmp/package.json
-COPY package-lock.json /tmp/package-lock.json
-RUN cd /tmp && npm install
-RUN mkdir -p /opt/app && cp -a /tmp/node_modules /opt/app/
-
 WORKDIR /opt/app
-COPY . /opt/app
-
 EXPOSE 50708
-
-CMD ["node", "index.js"]
+ENTRYPOINT ["./run.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,8 @@ services:
   mailgun-bouncebot:
     container_name: mailgun-bouncebot
     build: .
+    volumes:
+      - ./:/opt/app
     environment:
       - API_KEY
       - CC

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+cd /opt/app
+npm install
+
+node index.js
+


### PR DESCRIPTION
This prevents needing to re-pull dependencies every time the code is
changed.